### PR TITLE
Make mount base path dynamic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ ARCH="<SO arch>"
 HOST="local.$NAME.coop"
 PROJECT_NAME="<project name>"
 PROJECT_PATH="${PWD%/*}/$PROJECT_NAME"
+BASE_PATH="/opt"
 DEVENV_USER="<user that will own the project>"
 DEVENV_GROUP="<group that will own the project>"
 ```
@@ -38,7 +39,7 @@ Then run `devenv` in your project directory.
 The script will:
 
 * Create a container
-* Mount your project directory into container in `/opt/<project_name>`
+* Mount your project directory into container in `/<BASE_PATH>/<PROJECT_NAME>`
 * Add container IP to `/etc/hosts`
 * Create a group with same `gid` of project directory and named `$DEVENV_GROUP`
 * Create a user with same `uid` and `gid` of project directory and named `$DEVENV_USER`

--- a/create-container.sh
+++ b/create-container.sh
@@ -21,7 +21,7 @@ lxc.net.0.flags = up
 lxc.net.0.link = lxcbr0
 
 # Volumes
-lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs/opt/$PROJECT_NAME none bind,create=dir 0.0
+lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs/$BASE_PATH/$PROJECT_NAME none bind,create=dir 0.0
 EOL
 
 # Print configuration
@@ -33,6 +33,7 @@ echo "  - LXC Configuration: $LXC_CONFIG"
 echo "  - Host: $HOST"
 echo "  - Project Name: $PROJECT_NAME"
 echo "  - Project Directory: $PROJECT_PATH"
+echo "  - Will mount on: $BASE_PATH/$PROJECT_NAME"
 echo "  - User: $DEVENV_USER"
 echo "  - Group: $DEVENV_GROUP"
 echo


### PR DESCRIPTION
### WAT
Until now we always mount the project directory in `/opt` inside the container. We'll need to specify it from now on.

Partially Fix https://github.com/coopdevs/devenv/issues/8 (we still miss a default)