### PR TITLE
Make optional the PROJECT_PATH and PROJECT_NAME variables

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -9,6 +9,10 @@ set -e
 # shellcheck source=/dev/null
 source "$PWD/.devenv"
 
+# Defaults
+project_uid=1000
+project_gid=1000
+
 RETRIES=5
 
 # Create LXC config file
@@ -98,13 +102,17 @@ read -r ssh_key < "$ssh_path"
 echo "Copying system user's SSH public key to 'root' user in container"
 sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /root/.ssh && echo $ssh_key > /root/.ssh/authorized_keys"
 
-# Find `uid` of project directory
-project_user=$(stat -c '%U' "$PROJECT_PATH")
-project_uid=$(id -u "$project_user")
+# If PROJECT_PATH is not set, use the defaults project_uid and project_gid
+if [ -v "$PROJECT_PATH" ]
+then
+  # Find `uid` of project directory
+  project_user=$(stat -c '%U' "$PROJECT_PATH")
+  project_uid=$(id -u "$project_user")
 
-# Find `gid` of project directory
-project_group=$(stat -c '%G' "$PROJECT_PATH")
-project_gid=$(id -g "$project_group")
+  # Find `gid` of project directory
+  project_group=$(stat -c '%G' "$PROJECT_PATH")
+  project_gid=$(id -g "$project_group")
+fi
 
 # Delete existing user with same uid and gid of project directory
 existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$project_uid" 2>&1)

--- a/create-container.sh
+++ b/create-container.sh
@@ -25,8 +25,18 @@ lxc.net.0.flags = up
 lxc.net.0.link = lxcbr0
 
 # Volumes
-lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs/$BASE_PATH/$PROJECT_NAME none bind,create=dir 0.0
 EOL
+
+# TODO - We can extract all this conditions in functions and separate in files
+# Mount folder if PROJECT_PATH is defined
+if [ ! -v BASE_PATH ] ; then
+  BASE_PATH="/opt/"
+fi
+
+if [ -v PROJECT_PATH ] ; then
+  mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH$PROJECT_NAME none bind,create=dir 0.0"
+  echo "$mount_entry" >> "$LXC_CONFIG"
+fi
 
 # Print configuration
 echo "* CONFIGURATION:"
@@ -37,7 +47,7 @@ echo "  - LXC Configuration: $LXC_CONFIG"
 echo "  - Host: $HOST"
 echo "  - Project Name: $PROJECT_NAME"
 echo "  - Project Directory: $PROJECT_PATH"
-echo "  - Will mount on: $BASE_PATH/$PROJECT_NAME"
+echo "  - Will mount on: $BASE_PATH$PROJECT_NAME"
 echo "  - User: $DEVENV_USER"
 echo "  - Group: $DEVENV_GROUP"
 echo

--- a/create-container.sh
+++ b/create-container.sh
@@ -113,8 +113,7 @@ echo "Copying system user's SSH public key to 'root' user in container"
 sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /root/.ssh && echo $ssh_key > /root/.ssh/authorized_keys"
 
 # If PROJECT_PATH is not set, use the defaults project_uid and project_gid
-if [ -v "$PROJECT_PATH" ]
-then
+if  [ -v PROJECT_PATH ] ; then
   # Find `uid` of project directory
   project_user=$(stat -c '%U' "$PROJECT_PATH")
   project_uid=$(id -u "$project_user")

--- a/create-container.sh
+++ b/create-container.sh
@@ -30,11 +30,11 @@ EOL
 # TODO - We can extract all this conditions in functions and separate in files
 # Mount folder if PROJECT_PATH is defined
 if [ ! -v BASE_PATH ] ; then
-  BASE_PATH="/opt/"
+  BASE_PATH="/opt"
 fi
 
 if [ -v PROJECT_PATH ] ; then
-  mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH$PROJECT_NAME none bind,create=dir 0.0"
+  mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH/$PROJECT_NAME none bind,create=dir 0.0"
   echo "$mount_entry" >> "$LXC_CONFIG"
 fi
 
@@ -47,7 +47,7 @@ echo "  - LXC Configuration: $LXC_CONFIG"
 echo "  - Host: $HOST"
 echo "  - Project Name: $PROJECT_NAME"
 echo "  - Project Directory: $PROJECT_PATH"
-echo "  - Will mount on: $BASE_PATH$PROJECT_NAME"
+echo "  - Will mount on: $BASE_PATH/$PROJECT_NAME"
 echo "  - User: $DEVENV_USER"
 echo "  - Group: $DEVENV_GROUP"
 echo


### PR DESCRIPTION
In some projects, we don't need to mount a project folder.

With this change, we want to make optional the variables `PROJECT_PATH` and PROJECT_NAME` of the `devenv` configuration file.

* Checklist

- [x] Set defaults `project_uid` and `preject_gid`.
- [x] Use the defaults to create user and group if the configuration vars are not set.
- [x] Do the mount line conditional in the lxc configuration file.