### PR TITLE
Make users  and group management optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The script will:
 * Create a container
 * Mount your project directory into container in `/<BASE_PATH>/<PROJECT_NAME>`
 * Add container IP to `/etc/hosts`
-* Create a group with same `gid` of project directory and named `$DEVENV_GROUP` if `DEVENV_GROUP` or `DEVENV_USER` are defined.
-* Create a user with same `uid` and `gid` of project directory and named `$DEVENV_USER` if `DEVENV_GROUP` or `DEVENV_USER` are defined.
+* Create a group with same `gid` of project directory and named `$DEVENV_GROUP` if `DEVENV_GROUP` and `DEVENV_USER` are defined.
+* Create a user with same `uid` and `gid` of project directory and named `$DEVENV_USER` if `DEVENV_GROUP` and `DEVENV_USER` are defined.
 * Add system user's SSH public key to user
 * Install python2.7 in container
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ DISTRIBUTION="<SO distribution>"
 RELEASE="<SO release>"
 ARCH="<SO arch>"
 HOST="local.$NAME.coop"
+DEVENV_USER="<user that will own the project>" -- Optional
+DEVENV_GROUP="<group that will own the project>" -- Optional
+
+# Optional -- To mount a project
 PROJECT_NAME="<project name>"
 PROJECT_PATH="${PWD%/*}/$PROJECT_NAME"
 BASE_PATH="/opt"
-DEVENV_USER="<user that will own the project>"
-DEVENV_GROUP="<group that will own the project>"
 ```
 
 Then run `devenv` in your project directory.
@@ -41,8 +43,8 @@ The script will:
 * Create a container
 * Mount your project directory into container in `/<BASE_PATH>/<PROJECT_NAME>`
 * Add container IP to `/etc/hosts`
-* Create a group with same `gid` of project directory and named `$DEVENV_GROUP`
-* Create a user with same `uid` and `gid` of project directory and named `$DEVENV_USER`
+* Create a group with same `gid` of project directory and named `$DEVENV_GROUP` if `DEVENV_GROUP` or `DEVENV_USER` are defined.
+* Create a user with same `uid` and `gid` of project directory and named `$DEVENV_USER` if `DEVENV_GROUP` or `DEVENV_USER` are defined.
 * Add system user's SSH public key to user
 * Install python2.7 in container
 

--- a/create-container.sh
+++ b/create-container.sh
@@ -123,19 +123,21 @@ if  [ -v PROJECT_PATH ] ; then
   project_gid=$(id -g "$project_group")
 fi
 
-# Delete existing user with same uid and gid of project directory
-existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$project_uid" 2>&1)
-sudo lxc-attach -n "$NAME" -- /usr/sbin/userdel -r "$existing_user"
+if [ -v DEVENV_USER ] || [ -v DEVENV_GROUP ]; then
+  # Delete existing user with same uid and gid of project directory
+  existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$project_uid" 2>&1)
+  sudo lxc-attach -n "$NAME" -- /usr/sbin/userdel -r "$existing_user"
 
-# Create group with same `gid` of project directory
-sudo lxc-attach -n "$NAME" -- /usr/sbin/groupadd -f --gid "$project_gid" "$DEVENV_GROUP"
+  # Create group with same `gid` of project directory
+  sudo lxc-attach -n "$NAME" -- /usr/sbin/groupadd -f --gid "$project_gid" "$DEVENV_GROUP"
 
-# Create user with same `uid` and `gid` of project directory
-sudo lxc-attach -n "$NAME" -- /bin/sh -c "/usr/bin/id -u $DEVENV_USER || /usr/sbin/useradd --uid $project_uid --gid $project_gid --create-home --shell /bin/bash $DEVENV_USER"
+  # Create user with same `uid` and `gid` of project directory
+  sudo lxc-attach -n "$NAME" -- /bin/sh -c "/usr/bin/id -u $DEVENV_USER || /usr/sbin/useradd --uid $project_uid --gid $project_gid --create-home --shell /bin/bash $DEVENV_USER"
 
-# Add system user's SSH public key to user
-echo "Copying system user's SSH public key to $DEVENV_USER user in container"
-sudo lxc-attach -n "$NAME" -- sudo -u "$DEVENV_USER" -- sh -c "/bin/mkdir -p /home/$DEVENV_USER/.ssh && echo $ssh_key > /home/$DEVENV_USER/.ssh/authorized_keys"
+  # Add system user's SSH public key to user
+  echo "Copying system user's SSH public key to $DEVENV_USER user in container"
+  sudo lxc-attach -n "$NAME" -- sudo -u "$DEVENV_USER" -- sh -c "/bin/mkdir -p /home/$DEVENV_USER/.ssh && echo $ssh_key > /home/$DEVENV_USER/.ssh/authorized_keys"
+fi
 
 # Debian Stretch Sudo install
 sudo lxc-attach -n "$NAME" -- apt install sudo

--- a/create-container.sh
+++ b/create-container.sh
@@ -28,11 +28,11 @@ lxc.net.0.link = lxcbr0
 EOL
 
 # TODO - We can extract all this conditions in functions and separate in files
-# Mount folder if PROJECT_PATH is defined
 if [ ! -v BASE_PATH ] ; then
   BASE_PATH="/opt"
 fi
 
+# Mount folder if PROJECT_PATH is defined
 if [ -v PROJECT_PATH ] ; then
   mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH/$PROJECT_NAME none bind,create=dir 0.0"
   echo "$mount_entry" >> "$LXC_CONFIG"
@@ -47,7 +47,7 @@ echo "  - LXC Configuration: $LXC_CONFIG"
 echo "  - Host: $HOST"
 echo "  - Project Name: $PROJECT_NAME"
 echo "  - Project Directory: $PROJECT_PATH"
-echo "  - Will mount on: $BASE_PATH/$PROJECT_NAME"
+echo "  - Will mount on: $BASE_PATH$PROJECT_NAME"
 echo "  - User: $DEVENV_USER"
 echo "  - Group: $DEVENV_GROUP"
 echo
@@ -114,7 +114,7 @@ sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /root/.ssh && echo $ss
 
 # User management related with projects folder
 # If PROJECT_PATH is not set, use the defaults project_uid and project_gid
-if  [ -v "$PROJECT_PATH" ] ; then
+if  [ -v PROJECT_PATH ] ; then
   # Find `uid` of project directory
   project_user=$(stat -c '%U' "$PROJECT_PATH")
   project_uid=$(id -u "$project_user")

--- a/create-container.sh
+++ b/create-container.sh
@@ -10,9 +10,6 @@ set -e
 source "$PWD/.devenv"
 
 # Defaults
-project_uid=1000
-project_gid=1000
-
 RETRIES=5
 
 # Create LXC config file
@@ -126,7 +123,7 @@ fi
 
 # User management
 # If DEVENV_USER or DEVENV_GROUP is not set, the defaults user is not deleted.
-if [ -v DEVENV_USER ] || [ -v DEVENV_GROUP ]; then
+if [ -v DEVENV_USER ] && [ -v DEVENV_GROUP ] && [ -v project_uid ] && [ -v project_gid ]; then
   # Delete existing user with same uid and gid of project directory
   existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$project_uid" 2>&1)
   sudo lxc-attach -n "$NAME" -- /usr/sbin/userdel -r "$existing_user"

--- a/create-container.sh
+++ b/create-container.sh
@@ -112,6 +112,7 @@ read -r ssh_key < "$ssh_path"
 echo "Copying system user's SSH public key to 'root' user in container"
 sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /root/.ssh && echo $ssh_key > /root/.ssh/authorized_keys"
 
+# User management related with projects folder
 # If PROJECT_PATH is not set, use the defaults project_uid and project_gid
 if  [ -v PROJECT_PATH ] ; then
   # Find `uid` of project directory
@@ -123,6 +124,8 @@ if  [ -v PROJECT_PATH ] ; then
   project_gid=$(id -g "$project_group")
 fi
 
+# User management
+# If DEVENV_USER or DEVENV_GROUP is not set, the defaults user is not deleted.
 if [ -v DEVENV_USER ] || [ -v DEVENV_GROUP ]; then
   # Delete existing user with same uid and gid of project directory
   existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$project_uid" 2>&1)

--- a/create-container.sh
+++ b/create-container.sh
@@ -114,7 +114,7 @@ sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /root/.ssh && echo $ss
 
 # User management related with projects folder
 # If PROJECT_PATH is not set, use the defaults project_uid and project_gid
-if  [ -v PROJECT_PATH ] ; then
+if  [ -v "$PROJECT_PATH" ] ; then
   # Find `uid` of project directory
   project_user=$(stat -c '%U' "$PROJECT_PATH")
   project_uid=$(id -u "$project_user")

--- a/create-container.sh
+++ b/create-container.sh
@@ -44,7 +44,7 @@ echo "  - LXC Configuration: $LXC_CONFIG"
 echo "  - Host: $HOST"
 echo "  - Project Name: $PROJECT_NAME"
 echo "  - Project Directory: $PROJECT_PATH"
-echo "  - Will mount on: $BASE_PATH$PROJECT_NAME"
+echo "  - Will mount on: $BASE_PATH/$PROJECT_NAME"
 echo "  - User: $DEVENV_USER"
 echo "  - Group: $DEVENV_GROUP"
 echo
@@ -110,7 +110,6 @@ echo "Copying system user's SSH public key to 'root' user in container"
 sudo lxc-attach -n "$NAME" -- /bin/bash -c "/bin/mkdir -p /root/.ssh && echo $ssh_key > /root/.ssh/authorized_keys"
 
 # User management related with projects folder
-# If PROJECT_PATH is not set, use the defaults project_uid and project_gid
 if  [ -v PROJECT_PATH ] ; then
   # Find `uid` of project directory
   project_user=$(stat -c '%U' "$PROJECT_PATH")
@@ -122,7 +121,6 @@ if  [ -v PROJECT_PATH ] ; then
 fi
 
 # User management
-# If DEVENV_USER or DEVENV_GROUP is not set, the defaults user is not deleted.
 if [ -v DEVENV_USER ] && [ -v DEVENV_GROUP ] && [ -v project_uid ] && [ -v project_gid ]; then
   # Delete existing user with same uid and gid of project directory
   existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$project_uid" 2>&1)


### PR DESCRIPTION
This PR depends on #12

The users and group creation are not always needed. For this reason, we need to make these functionalities optional. Depends on the `DEVENV_USER` and `DEVENV_GROUP` vars.

* Checklist 

- [x] Manage user and group creation depends on `DEVENV_USER` and `DEVENV_GROUP` vars.