### PR TITLE
Install sudo for Debian Stretch. Needed to the other installations

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -121,8 +121,7 @@ echo "Copying system user's SSH public key to $DEVENV_USER user in container"
 sudo lxc-attach -n "$NAME" -- sudo -u "$DEVENV_USER" -- sh -c "/bin/mkdir -p /home/$DEVENV_USER/.ssh && echo $ssh_key > /home/$DEVENV_USER/.ssh/authorized_keys"
 
 # Debian Stretch Sudo install
-if [ $DISTRIBUTION == "debian" ] && [ $RELEASE == "stretch" ]; then
-  sudo lxc-attach -n "$NAME" -- apt install sudo
+sudo lxc-attach -n "$NAME" -- apt install sudo
 
 # Install python2.7 in container
 echo "Installing Python2.7 in container $NAME"

--- a/create-container.sh
+++ b/create-container.sh
@@ -120,6 +120,10 @@ sudo lxc-attach -n "$NAME" -- /bin/sh -c "/usr/bin/id -u $DEVENV_USER || /usr/sb
 echo "Copying system user's SSH public key to $DEVENV_USER user in container"
 sudo lxc-attach -n "$NAME" -- sudo -u "$DEVENV_USER" -- sh -c "/bin/mkdir -p /home/$DEVENV_USER/.ssh && echo $ssh_key > /home/$DEVENV_USER/.ssh/authorized_keys"
 
+# Debian Stretch Sudo install
+if [ $DISTRIBUTION == "debian" ] && [ $RELEASE == "stretch" ]; then
+  sudo lxc-attach -n "$NAME" -- apt install sudo
+
 # Install python2.7 in container
 echo "Installing Python2.7 in container $NAME"
 sudo lxc-attach -n "$NAME" -- sudo apt update


### PR DESCRIPTION
## Debian support

I need Debian support for the Tryton projects and to add support to Debian Stretch release I need install first of any package installation the `sudo` package.

With this PR the script checks if is the `DISTRIBUTION` and the `RELEASE` are `debian` and `stretch` and in this case install the `sudo` package.