### PR TITLE
Install the Python interpreter selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,18 @@ DISTRIBUTION="<SO distribution>"
 RELEASE="<SO release>"
 ARCH="<SO arch>"
 HOST="local.$NAME.coop"
-DEVENV_USER="<user that will own the project>" -- Optional
-DEVENV_GROUP="<group that will own the project>" -- Optional
+
+# Optional -- To create a new user and group
+DEVENV_USER="<user that will own the project>"
+DEVENV_GROUP="<group that will own the project>"
 
 # Optional -- To mount a project
 PROJECT_NAME="<project name>"
 PROJECT_PATH="${PWD%/*}/$PROJECT_NAME"
-BASE_PATH="/opt"
+BASE_PATH="<base project path>"
+
+# Optional -- To install Python2.7 interpeter
+PYTHON2=yes
 ```
 
 Then run `devenv` in your project directory.

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ PROJECT_NAME="<project name>"
 PROJECT_PATH="${PWD%/*}/$PROJECT_NAME"
 BASE_PATH="<base project path>"
 
-# Optional -- To install Python2.7 interpeter
-PYTHON2=yes
+# Select the python interpeter python2.7 or python3
+PYTHON_INTERPRETER=python3
 ```
 
 Then run `devenv` in your project directory.
@@ -51,6 +51,6 @@ The script will:
 * Create a group with same `gid` of project directory and named `$DEVENV_GROUP` if `DEVENV_GROUP` and `DEVENV_USER` are defined.
 * Create a user with same `uid` and `gid` of project directory and named `$DEVENV_USER` if `DEVENV_GROUP` and `DEVENV_USER` are defined.
 * Add system user's SSH public key to user
-* Install python2.7 in container
+* Install python in container
 
 When the execution ends, you'll have a container ready to provision and deploy your project.

--- a/create-container.sh
+++ b/create-container.sh
@@ -140,12 +140,10 @@ fi
 # Debian Stretch Sudo install
 sudo lxc-attach -n "$NAME" -- apt install sudo
 
-if [ -v PYTHON2 ]; then
-  # Install python2.7 in container
-  echo "Installing Python2.7 in container $NAME"
-  sudo lxc-attach -n "$NAME" -- sudo apt update
-  sudo lxc-attach -n "$NAME" -- sudo apt install -y python2.7
-fi
+# Install python interpreter in container
+echo "Installing Python in container $NAME"
+sudo lxc-attach -n "$NAME" -- sudo apt update
+sudo lxc-attach -n "$NAME" -- sudo apt install -y "$PYTHON_INTERPRETER"
 
 # Install SSH server in container
 echo "Installing SSH server in container $NAME"

--- a/create-container.sh
+++ b/create-container.sh
@@ -140,10 +140,12 @@ fi
 # Debian Stretch Sudo install
 sudo lxc-attach -n "$NAME" -- apt install sudo
 
-# Install python2.7 in container
-echo "Installing Python2.7 in container $NAME"
-sudo lxc-attach -n "$NAME" -- sudo apt update
-sudo lxc-attach -n "$NAME" -- sudo apt install -y python2.7
+if [ -v PYTHON2 ]; then
+  # Install python2.7 in container
+  echo "Installing Python2.7 in container $NAME"
+  sudo lxc-attach -n "$NAME" -- sudo apt update
+  sudo lxc-attach -n "$NAME" -- sudo apt install -y python2.7
+fi
 
 # Install SSH server in container
 echo "Installing SSH server in container $NAME"


### PR DESCRIPTION
## Why?

Now we are starting to use Python3 to run Ansible scripts and is already installed in the newest versions of Ubuntu.

In the future, we can remove this part of the script, but now we need to maintain the Python2.7 for any projects and Python3 to another one.