### PR TITLE
Display root user when no DEVENV_USER is provided

### DIFF
--- a/config
+++ b/config
@@ -9,6 +9,7 @@
 # Number of times to retest if container is started and IP assigned
 # RETRIES=0 means 1 attempt and 0 retries.
 RETRIES=5
+DEVENV_USER=${DEVENV_USER:-root}
 
 # SSH certificate to log in to the SSH server inside the container
 SSH_KEY_PATH="$HOME/.ssh/id_rsa.pub"

--- a/create-container.sh
+++ b/create-container.sh
@@ -189,6 +189,7 @@ echo "Installing SSH server in container $NAME"
 sudo lxc-attach -n "$NAME" -- sudo apt install -y openssh-server
 
 # Ready to provision the container
+echo
 echo "Very well! LXC container $NAME has been created and configured"
 echo
 echo "You should be able to access using:"


### PR DESCRIPTION
So this way we display

```
You should be able to access using:
> ssh root@ofn.local
```

upon completion instead of `ssh @ofn.local`. You'll notice this is a revert commit. Sorry I fucked up pushing to master :grin:. So this is the revert of the revert I then pushed to master (I guess you got lost?).
