### PR TITLE
Ignore error deleting default user

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -163,11 +163,14 @@ if  [ -v PROJECT_PATH ] ; then
   PROJECT_GID=$(id -g "$PROJECT_GROUP")
 fi
 
+echo "$PROJECT_UID"
+
 # User management
 if [ -v DEVENV_USER ] && [ -v DEVENV_GROUP ] && [ -v PROJECT_UID ] && [ -v PROJECT_GID ]; then
   # Delete existing user with same uid and gid of project directory
-  existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$PROJECT_UID" 2>&1)
-  sudo lxc-attach -n "$NAME" -- /usr/sbin/userdel -r "$existing_user"
+  # If the user does not exist ignore the assignment and deletion error
+  ! existing_user=$(sudo lxc-attach -n "$NAME" -- id -nu "$PROJECT_UID" 2>&1)
+  ! sudo lxc-attach -n "$NAME" -- /usr/sbin/userdel -r "$existing_user"
 
   # Create group with same `gid` of project directory
   sudo lxc-attach -n "$NAME" -- /usr/sbin/groupadd -f --gid "$PROJECT_GID" "$DEVENV_GROUP"


### PR DESCRIPTION
If the user with the same UUID that the owner of the project folder
ignore the errors raised in the search and deleting of this user.

Use the `!` to ignore the error:

----
[StackOverflow answer](https://stackoverflow.com/a/29784820)
From the POSIX specification regarding set -e (emphasis mine):

> When this option is on, if a simple command fails for any of the reasons listed in Consequences of Shell Errors or returns an exit status value >0, and is not part of the compound list following a while, until, or if keyword, and is not a part of an AND or OR list, and is not a pipeline preceded by the ! reserved word, then the shell shall immediately exit.
----

Closes #22 