### PR TITLE
Manage missing project path

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -37,8 +37,9 @@ if [ ! -v BASE_PATH ] ; then
   BASE_PATH="/opt"
 fi
 
-# Mount folder if PROJECT_PATH is defined
+# If PROJECT_PATH is defined, create folder if non-existant, and mount it
 if [ -v PROJECT_PATH ] ; then
+  mkdir -p "$PROJECT_PATH"
   mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH/$PROJECT_NAME none bind,create=dir 0.0"
   echo "$mount_entry" >> "$LXC_CONFIG"
 fi

--- a/create-container.sh
+++ b/create-container.sh
@@ -37,9 +37,16 @@ if [ ! -v BASE_PATH ] ; then
   BASE_PATH="/opt"
 fi
 
-# If PROJECT_PATH is defined, create folder if non-existant, and mount it
-if [ -v PROJECT_PATH ] ; then
-  mkdir -p "$PROJECT_PATH"
+# About PROJECT_PATH:
+# If it is not set, skip this section
+if [ ! -v PROJECT_PATH ] ; then
+  echo "PROJECT_PATH is undefined, will not mount a host-container shared directory"
+# If defined but does not exists, exit with an error
+elif [ ! -d "$PROJECT_PATH" ]; then
+  echo "Shared directory \"$PROJECT_PATH\" does not exist. Create it or unset variable \$PROJECT_PATH"
+  exit 1
+# Otherwise, we've got what we need. Configure the container to mount the shared dir.
+else
   mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH/$PROJECT_NAME none bind,create=dir 0.0"
   echo "$mount_entry" >> "$LXC_CONFIG"
 fi


### PR DESCRIPTION
Prevents devenv to fail when starting the container, who tries to mount the project dir and fails.

On my machine, I had this obscure output:
```
[···]
Container is created
Starting container...
lxc-start: tools/lxc_start.c: main: 366 The container failed to start.
lxc-start: tools/lxc_start.c: main: 368 To get more details, run the container in foreground mode.
lxc-start: tools/lxc_start.c: main: 370 Additional information can be obtained by setting the --logfile and --logpriority options
```
It solves a frequent cause of error  (at least common to me)

`mkdir -p` only creates the dir if missing and doesn't do anything otherwise