### PR TITLE
Avoid error when known_hosts is not created or there are no ssh keys

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -107,7 +107,7 @@ if [ ! -v BASE_PATH ] ; then
 fi
 
 # Test if known_hosts file exists
-if [ ! -f ~/.ssh/know_hosts ] ; then
+if [ ! -f ~/.ssh/known_hosts ] ; then
   touch ~/.ssh/known_hosts
 fi
 

--- a/create-container.sh
+++ b/create-container.sh
@@ -108,7 +108,7 @@ fi
 
 # Test if known_hosts file exists
 if [ ! -f ~/.ssh/know_hosts ] ; then
-  touch ~/.ssh/know_hosts
+  touch ~/.ssh/known_hosts
 fi
 
 # Test if public key created

--- a/create-container.sh
+++ b/create-container.sh
@@ -113,7 +113,9 @@ fi
 
 # Test if public key created
 if [ ! -f ~/.ssh/id_rsa.pub ] ; then
-  ssh-keygen -t rsa -N "" -q -f "$HOME/.ssh/id_rsa"
+  echo "I can't find a SSH public key in the default path: `$HOME/.ssh/id_rsa`."
+  echo "You can use the var SSH_KEY_PATH to set a different path if you don't use the default."
+  exit 0
 fi
 
 # About PROJECT_PATH:

--- a/create-container.sh
+++ b/create-container.sh
@@ -106,6 +106,16 @@ if [ ! -v BASE_PATH ] ; then
   BASE_PATH="/opt"
 fi
 
+# Test if known_hosts file exists
+if [ ! -f ~/.ssh/know_hosts ] ; then
+  touch ~/.ssh/know_hosts
+fi
+
+# Test if public key created
+if [ ! -f ~/.ssh/id_rsa.pub ] ; then
+  ssh-keygen -t rsa -N "" -q -f "$HOME/.ssh/id_rsa"
+fi
+
 # About PROJECT_PATH:
 # If it is not set, skip this section
 if [ ! -v PROJECT_PATH ] ; then


### PR DESCRIPTION
Adding test for existing file known_host and ssh key created before container created