### PR TITLE
Protect sed-delete regexes

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -214,8 +214,8 @@ sudo -- sh -c "echo \"$HOST_ENTRY_COMMENT\" >> /etc/hosts"
 for HOST in $HOSTS; do
   HOST_ENTRY="$IP_CONTAINER        $HOST"
   echo "Removing old host $HOST from /etc/hosts"
-  sudo sed -i "/$HOST_ENTRY/d" /etc/hosts
-  sudo sed -i "/$IP_CONTAINER/d" /etc/hosts
+  sudo sed -i "/^$HOST_ENTRY$/d" /etc/hosts
+  sudo sed -i "/^$IP_CONTAINER /d" /etc/hosts
 done
 
 for HOST in $HOSTS; do


### PR DESCRIPTION
from https://github.com/coopdevs/devenv/pull/37#discussion_r647446945

---

Hi! I think these 2 lines are dangerous. When the expressions are not bounded, they can match on similar, longer ones.

For instance, line 217 would delete both lines in this case:
```bash
# HOST=odoo.coopdevs.org
# IP_CONTAINER=192.168.122.10
192.168.122.10        odoo.coopdevs.org
192.168.122.10        odoo.coopdevs.org.local
```
It's an edge case, but I would add start and end line delimiters:
`sudo sed -i "/^$HOST_ENTRY$/d" /etc/hosts`

Line 218 I find it more dangerous, cause it's a smaller part of a line. This case is more possible:
```bash
# HOST=odoo.coopdevs.org
# IP_CONTAINER=192.168.122.10
192.168.122.100        odoo.processos.org
192.168.122.10        odoo.coopdevs.local
```
Both lines would be deleted because both contain the string `192.168.122.10`. In this case, I would try again to set the boundaries:
`sudo sed  -i "/^$IP_CONTAINER /d" /etc/hosts`
The left boundary, line start, and the right boundary a blankspace. You can use something more visual as \w or \\> for generic white or for word delimiter, but this one works universally and the other methods I'm not sure of the platform scope they actually work in.

Finally, domains that share the same IP can be written in the same line. Maybe it's easier to do `HOST_ENTRY=$IP_CONTAINER        $HOSTS`. To delete, it would work the same way, although it should be easy to find simpler ways.