### PR TITLE
Adding other project paths

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -132,6 +132,13 @@ else
   echo "$mount_entry" >> "$LXC_CONFIG"
 fi
 
+# Mounting other project paths
+for other_project_path in "${OTHER_PROJECTS_PATHS[@]}"; do
+  other_project_name=$(basename "$other_project_path")
+  mount_entry="lxc.mount.entry = "$other_project_path" /var/lib/lxc/$NAME/rootfs$BASE_PATH/$other_project_name none bind,create=dir 0.0"
+  echo "$mount_entry" >> "$LXC_CONFIG"
+done
+
 if [ -z "${HOSTS}" ] ; then
   HOSTS=$HOST;
 fi


### PR DESCRIPTION
This feature expects a `.devenv` file with the following config:

```bash
PROJECT_NAME="main_project"
PROJECT_PATH="${PWD%/*}/$NAME/$PROJECT_NAME"

#New OTHER_PROJECTS_PATHS variable
declare -a OTHER_PROJECTS_PATHS=(
"/home/username/Documents/odoo/server-auth/auth_keycloak"
"/home/username/Documents/odoo/odoo-addons/hr_holidays_notify_extra/"
)

BASE_PATH="/opt/odoo_modules"

```