### PR TITLE
Add PROJECT_POST_PATH var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ DEVENV_GROUP="<group that will own the project>"
 PROJECT_NAME="<project name>"
 PROJECT_PATH="${PWD%/*}/$PROJECT_NAME"
 BASE_PATH="<base project path>"
+PROJECT_POST_PATH="<post project path>"
 
 # Select the python interpeter python2.7 or python3
 PYTHON_INTERPRETER=python3
@@ -63,7 +64,7 @@ Then run `devenv` in your project directory.
 The script will:
 
 * Create a container
-* Mount your project directory into container in `/<BASE_PATH>/<PROJECT_NAME>`
+* Mount your project directory into container in `/<BASE_PATH>/<PROJECT_NAME>/<PROJECT_POST_PATH>`
 * Add container IP to `/etc/hosts`
 * Create a group with same `gid` of project directory and named `$DEVENV_GROUP` if `DEVENV_GROUP` and `DEVENV_USER` are defined.
 * Create a user with same `uid` and `gid` of project directory and named `$DEVENV_USER` if `DEVENV_GROUP` and `DEVENV_USER` are defined.

--- a/create-container.sh
+++ b/create-container.sh
@@ -105,6 +105,9 @@ echo "$LXC_CONFIG_CONTENT" > "$LXC_CONFIG"
 if [ ! -v BASE_PATH ] ; then
   BASE_PATH="/opt"
 fi
+if [ ! -v PROJECT_POST_PATH ] ; then
+  PROJECT_POST_PATH=""
+fi
 
 # Test if known_hosts file exists
 if [ ! -f ~/.ssh/known_hosts ] ; then
@@ -128,7 +131,7 @@ elif [ ! -d "$PROJECT_PATH" ]; then
   exit 1
 # Otherwise, we've got what we need. Configure the container to mount the shared dir.
 else
-  mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH/$PROJECT_NAME none bind,create=dir 0.0"
+  mount_entry="lxc.mount.entry = $PROJECT_PATH /var/lib/lxc/$NAME/rootfs$BASE_PATH/$PROJECT_NAME/$PROJECT_POST_PATH none bind,create=dir 0.0"
   echo "$mount_entry" >> "$LXC_CONFIG"
 fi
 


### PR DESCRIPTION
We use the variable PROJECT_POST_PATH to mount the local project folder in a concrete path.