### PR TITLE
fix: get only IP4 from container

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -192,7 +192,7 @@ echo "Container is running"
 
 # Wait to start container and check the IP
 COUNT=1
-IP_CONTAINER="$(sudo lxc-info -n "$NAME" -iH)"
+IP_CONTAINER="$(sudo lxc-info -n "$NAME" -iH | grep -oP '(\d{1,3}\.){3}\d{1,3}')"
 while [ -z "$IP_CONTAINER" ] ; do
   # LOOP START #
   if [ "$COUNT" -gt "$RETRIES" ]; then


### PR DESCRIPTION
If both IP4 and IP6 address are assigned to container, editing `/etc/hosts` fails with following message:

```quote
Removing old host test.local from /etc/hosts
sed: -e expression #1, char 12: unterminated address regex
```

This PR filters the output by using `grep` to store only the IP4:

```bash
IP_CONTAINER="$(sudo lxc-info -n "$NAME" -iH)| grep -oP '(\d{1,3}\.){3}\d{1,3}')"
```
