### PR TITLE
Fix IPv4 get lines

### DIFF
--- a/create-container.sh
+++ b/create-container.sh
@@ -192,7 +192,7 @@ echo "Container is running"
 
 # Wait to start container and check the IP
 COUNT=1
-IP_CONTAINER="$(sudo lxc-info -n "$NAME" -iH | grep -oP '(\d{1,3}\.){3}\d{1,3}')"
+IP_CONTAINER="$(sudo lxc-info -n "$NAME" -iH)"
 while [ -z "$IP_CONTAINER" ] ; do
   # LOOP START #
   if [ "$COUNT" -gt "$RETRIES" ]; then
@@ -208,6 +208,7 @@ while [ -z "$IP_CONTAINER" ] ; do
   # LOOP END #
   IP_CONTAINER="$(sudo lxc-info -n "$NAME" -iH)"
 done
+IP_CONTAINER="$(echo "$IP_CONTAINER" | grep -oP '(\d{1,3}\.){3}\d{1,3}')"
 echo "Container has IP address: $IP_CONTAINER"
 echo
 


### PR DESCRIPTION
Without these changes, the script ends after creating the container, waiting for the IP address.

This unexpected behavior occurs because the `grep` command fails if `lxc-ls` doesn't return the expected string. By separating `lxc-ls` from `grep`, we can avoid this issue.

This also fixes the case when the IP is not ready the first time, as in the loop, we don't execute the grep to extract the IPv4.